### PR TITLE
Improve the plugin error message when invalid credentials are set in the wiz.spc file closes #12

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -17,6 +17,7 @@ type Client struct {
 }
 
 func CreateClient(ctx context.Context, config ClientConfig) (*Client, error) {
+	
 	return &Client{
 		Token:   config.Token,
 		Graphql: graphql.NewClient(types.StringValue(config.Url)),

--- a/wiz/service.go
+++ b/wiz/service.go
@@ -115,8 +115,13 @@ func accessTokenUncached(ctx context.Context, d *plugin.QueryData, _ *plugin.Hyd
 
 	// Make a request to get the token
 	resp, err := client.Do(r)
+
 	if err != nil {
 		return nil, fmt.Errorf("error getting token response. Status: %s, err: %v", resp.Status, err)
+	}
+
+	if resp.Status != "200 OK" {
+		return nil, fmt.Errorf("failed to generate access token, please verify your connection config. Status: %s", resp.Status)
 	}
 
 	// Read the response body


### PR DESCRIPTION


# Example query results
<details>
  <summary>Results</summary>

```
Add example SQL query results here (please include the input queries as well)
```
</details>

Instead of returning `Error: wiz: failed to parse token response: invalid character 'U' looking for beginning of value`, the plugin will now return `Error: wiz: failed to generate access token, please verify your connection config. Status: 401 Unauthorized` in the event of invalid config arguments
