### PR TITLE
Fix CloudConfigRule struct to use pointer for Control field closes #49

### DIFF
--- a/api/cloudConfigRule.go
+++ b/api/cloudConfigRule.go
@@ -83,7 +83,7 @@ query GetCloudConfigRule($id: ID!) {
 type CloudConfigRule struct {
 	BuiltIn                 bool                               `json:"builtin"`
 	CloudProvider           string                             `json:"cloudProvider"`
-	Control                 []CloudConfigRuleQueryControl      `json:"control"`
+	Control                 *CloudConfigRuleQueryControl       `json:"control"`
 	CreatedAt               string                             `json:"createdAt"`
 	CreatedBy               CloudConfigRuleQueryUser           `json:"createdBy"`
 	Description             string                             `json:"description"`


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>

```
Add example SQL query results here (please include the input queries as well)
```
</details>
